### PR TITLE
Multiprocess Autorun

### DIFF
--- a/simulator.py
+++ b/simulator.py
@@ -4,6 +4,7 @@ from utils import all_logging_disabled
 import logging
 import numpy as np
 import datetime
+from multiprocessing import Pool, cpu_count
 
 logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
 
@@ -33,8 +34,49 @@ def get_args():
     parser.add_argument("--display_save_path", type=str, default="plots/")
     parser.add_argument("--autoplay", action="store_true", default=False)
     parser.add_argument("--autoplay_runs", type=int, default=100)
+    parser.add_argument(
+        "--num_cores",
+        type=int,
+        default=None,
+        help="Number of CPU cores to use. Default is all available cores.",
+    )
     args = parser.parse_args()
     return args
+
+
+def run_single_game(args_tuple):
+    """Helper function to run a single game for parallel processing"""
+    # Disable all logging for the individual game execution
+    with all_logging_disabled():
+        game_id, args, valid_board_sizes = args_tuple
+
+        # Create a new simulator instance for this game
+        simulator = Simulator(args)
+
+        # Determine if players should be swapped for this game
+        swap_players = game_id % 2 == 0
+
+        # Select random board size
+        board_size = valid_board_sizes[np.random.randint(len(valid_board_sizes))]
+
+        # Run the game
+        p0_score, p1_score, p0_time, p1_time = simulator.run(
+            swap_players=swap_players, board_size=board_size
+        )
+
+        # Adjust scores if players were swapped
+        if swap_players:
+            p0_score, p1_score, p0_time, p1_time = p1_score, p0_score, p1_time, p0_time
+
+        # Return results
+        return {
+            "p0_score": p0_score,
+            "p1_score": p1_score,
+            "p0_time": p0_time,
+            "p1_time": p1_time,
+            "board_size": board_size,
+            "was_swapped": swap_players,
+        }
 
 
 class Simulator:
@@ -49,8 +91,11 @@ class Simulator:
     def __init__(self, args):
         self.args = args
         # Only play on even-sized boards
-        self.valid_board_sizes = [ i for i in range(self.args.board_size_min, self.args.board_size_max+1) if i % 2 == 0 ]
-        #print("Valid sizes: ",self.valid_board_sizes)
+        self.valid_board_sizes = [
+            i
+            for i in range(self.args.board_size_min, self.args.board_size_max + 1)
+            if i % 2 == 0
+        ]
 
     def reset(self, swap_players=False, board_size=None):
         """
@@ -82,60 +127,96 @@ class Simulator:
         )
 
     def run(self, swap_players=False, board_size=None):
+        """
+        Run a single game until completion.
+
+        Parameters
+        ----------
+        swap_players : bool
+            if True, swap the players
+        board_size : int
+            if not None, set the board size
+
+        Returns
+        -------
+        tuple
+            (p0_score, p1_score, p0_time, p1_time)
+        """
         self.reset(swap_players=swap_players, board_size=board_size)
         is_end, p0_score, p1_score = self.world.step()
         while not is_end:
             is_end, p0_score, p1_score = self.world.step()
-        logger.info(
-            f"Run finished. {PLAYER_1_NAME} player, agent {self.args.player_1}: {p0_score}. {PLAYER_2_NAME}, agent {self.args.player_2}: {p1_score}"
-        )
         return p0_score, p1_score, self.world.p0_time, self.world.p1_time
 
     def autoplay(self):
         """
-        Run multiple simulations of the gameplay and aggregate win %
+        Run multiple simulations of the gameplay in parallel and aggregate win %.
+        Uses multiprocessing to utilize all available CPU cores for faster execution.
         """
+        if self.args.display:
+            logger.warning("Since running autoplay mode, display will be disabled")
+        self.args.display = False
+
+        # Determine number of cores to use
+        num_cores = self.args.num_cores or cpu_count()
+        num_cores = min(num_cores, self.args.autoplay_runs)
+
+        logger.info(
+            f"Running {self.args.autoplay_runs} games using {num_cores} cores..."
+        )
+
+        # Prepare arguments for parallel processing
+        game_args = [(i, self.args, [6]) for i in range(self.args.autoplay_runs)]
+
+        # Run games in parallel
+        with Pool(num_cores) as pool:
+            results = pool.map(run_single_game, game_args)
+
+        # Aggregate results
         p1_win_count = 0
         p2_win_count = 0
         p1_times = []
         p2_times = []
-        if self.args.display:
-            logger.warning("Since running autoplay mode, display will be disabled")
-        self.args.display = False
+        board_sizes_used = []
+
+        for result in results:
+            if result["p0_score"] > result["p1_score"]:
+                p1_win_count += 1
+            elif result["p0_score"] < result["p1_score"]:
+                p2_win_count += 1
+            else:  # Tie
+                p1_win_count += 0.5
+                p2_win_count += 0.5
+
+            p1_times.extend(result["p0_time"])
+            p2_times.extend(result["p1_time"])
+            board_sizes_used.append(result["board_size"])
+
+        # Calculate statistics
+        p1_win_rate = p1_win_count / self.args.autoplay_runs
+        p2_win_rate = p2_win_count / self.args.autoplay_runs
+        p1_max_time = np.round(np.max(p1_times), 5)
+        p2_max_time = np.round(np.max(p2_times), 5)
+
+        # Report final results
+        logger.info("\nResults Summary:")
+        logger.info("=" * 50)
+        logger.info(f"Total Games Played: {self.args.autoplay_runs}")
+        logger.info(f"Board Sizes Used: {sorted(set(board_sizes_used))}")
+        logger.info(f"\nPlayer 1 ({self.args.player_1}):")
+        logger.info(f"  Win Rate: {p1_win_rate:.2%}")
+        logger.info(f"  Maximum Turn Time: {p1_max_time} seconds")
+        logger.info(f"\nPlayer 2 ({self.args.player_2}):")
+        logger.info(f"  Win Rate: {p2_win_rate:.2%}")
+        logger.info(f"  Maximum Turn Time: {p2_max_time} seconds")
+        logger.info("=" * 50)
+
+        # Create a temporary world just to get player names for the CSV
         with all_logging_disabled():
-            for i in range(self.args.autoplay_runs):
-                swap_players = i % 2 == 0
-                board_size = self.valid_board_sizes[ np.random.randint(len(self.valid_board_sizes)) ] 
-                p0_score, p1_score, p0_time, p1_time = self.run(
-                    swap_players=swap_players, board_size=board_size
-                )
-                if swap_players:
-                    p0_score, p1_score, p0_time, p1_time = (
-                        p1_score,
-                        p0_score,
-                        p1_time,
-                        p0_time,
-                    )
-                if p0_score > p1_score:
-                    p1_win_count += 1
-                elif p0_score < p1_score:
-                    p2_win_count += 1
-                else:  # Tie
-                    p1_win_count += 0.5
-                    p2_win_count += 0.5
-                p1_times.extend(p0_time)
-                p2_times.extend(p1_time)
+            self.reset(
+                board_size=6
+            )  # This creates self.world with correct player names
 
-        logger.info(
-            f"Player 1, agent {self.args.player_1}, win percentage: {p1_win_count / self.args.autoplay_runs}. Maximum turn time was {np.round(np.max(p1_times),5)} seconds."
-        )
-        logger.info(
-            f"Player 2, agent {self.args.player_2}, win percentage: {p2_win_count / self.args.autoplay_runs}. Maximum turn time was {np.round(np.max(p2_times),5)} seconds."
-        )
-
-        """
-        The code in this comment will be part of the book-keeping that we use to score the end-of-term tournament. FYI. 
-        Uncomment and use it if you find this book-keeping helpful.
         fname = (
             "tournament_results/"
             + self.world.player_1_name
@@ -146,11 +227,13 @@ class Simulator:
             + ".csv"
         )
         with open(fname, "w") as fo:
-            fo.write(f"P1Name,P2Name,NumRuns,P1WinPercent,P2WinPercent,P1RunTime,P2RunTime\n")
+            fo.write(
+                "P1Name,P2Name,NumRuns,P1WinPercent,P2WinPercent,P1RunTime,P2RunTime\n"
+            )
             fo.write(
                 f"{self.world.player_1_name},{self.world.player_2_name},{self.args.autoplay_runs},{p1_win_count / self.args.autoplay_runs},{p2_win_count / self.args.autoplay_runs},{np.round(np.max(p1_times),5)},{np.round(np.max(p2_times),5)}\n"
             )
-        """
+
 
 if __name__ == "__main__":
     args = get_args()


### PR DESCRIPTION
# Add parallel processing support for autoplay testing
### This does not affect functionality. It is purely QoL, but I think everyone will appreciate it. (10x faster on my macbook pro!)

## Changes
- Added multiprocessing to run autoplay games in parallel
- Added `--num_cores` argument (defaults to using all CPU cores)

## Usage
```bash
# Use all cores
python simulator.py --autoplay --autoplay_runs 100

# Specify core count
python simulator.py --autoplay --autoplay_runs 100 --num_cores 4